### PR TITLE
Added muti-file sort capability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,16 @@ that is used internally by Doodle. Forked off @oliverwehrens.
 
 Additional features
 -------------------
-Automatic sorting of properties  
-Proper handling of ResourceBundle Plugin (inserts "\ " instead of just " ")  
-Todo: turn the Code -> Sort Properties action into sort all properties or/and remove duplicates/unused  
+* Automatic sorting of properties  
+* Proper handling of ResourceBundle Plugin (inserts "\ " instead of just " ")  
+* Sort Properties action can now sort multiple files. User selects one or more properties files in Intellij and then 
+selects Code > Sort Properties.
+  * The result of sorting the properties files is displayed in a table in a dialog window. There is one row displayed
+    per file.
+
+To Do
+------
+Remove duplicates/unused  
 
 
 How to build
@@ -14,4 +21,15 @@ Basically I followed this guide: http://confluence.jetbrains.com/display/IDEADEV
 Long story short: install IntelliJ Community edition and get the sources.  
 Create a Plugin Project and make sure you have a Java6 SDK as well as the IntelliJ SDK (the source code).
 Hack away, Build -> Make project, Build -> Prepare Plugin for Deployment.
+
+How to build with gradle
+------------------------
+Use task `buildPlugin` to build:
+
+```shell script
+./gradlew buildPlugin
+```
+
+See: [Getting Started with Gradle](https://plugins.jetbrains.com/docs/intellij/gradle-prerequisites.html) for details.
+
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,5 +46,4 @@ dependencies {
     compile 'org.apache.commons:commons-configuration2:2.4'
     
     testImplementation 'org.testng:testng:6.8'
-
 }

--- a/build.gradle
+++ b/build.gradle
@@ -44,4 +44,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.8'
     compile 'commons-beanutils:commons-beanutils:1.9.3'
     compile 'org.apache.commons:commons-configuration2:2.4'
+    
+    testImplementation 'org.testng:testng:6.8'
+
 }

--- a/src/main/java/net/wehrens/intellij/plugins/propertysorter/SortPropertiesAction.java
+++ b/src/main/java/net/wehrens/intellij/plugins/propertysorter/SortPropertiesAction.java
@@ -1,17 +1,22 @@
 package net.wehrens.intellij.plugins.propertysorter;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DataKeys;
-import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.CommandProcessor;
 import com.intellij.openapi.command.UndoConfirmationPolicy;
 import com.intellij.openapi.editor.Document;
-import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.vfs.VirtualFile;
+
+import net.wehrens.intellij.plugins.propertysorter.ui.SortPropertiesResultsPanel;
+
 
 public class SortPropertiesAction extends AnAction {
 
@@ -19,46 +24,72 @@ public class SortPropertiesAction extends AnAction {
   private StringPropertyConverter stringPropertyConverter = new StringPropertyConverter();
 
   public void actionPerformed(AnActionEvent e) {
-    // todo: turn this into a sort all property files method
-    final Editor editor = e.getData(DataKeys.EDITOR);
-    final String fileText = e.getData(DataKeys.FILE_TEXT);
-    MessageWindowComponent messageWindowComponent = getMessageComponent();
-
-    if (fileText != null) {
-      try {
-        Properties properties = stringPropertyConverter.convertString(fileText);
-        List<String> sortedKeys = propertySorter.getSortedKeys(properties);
-        final String newDocumentContent = stringPropertyConverter.sortAndConvertProperties(properties,
-                                                                                          sortedKeys);
-
-
-        ApplicationManager.getApplication().runWriteAction(new Runnable() {
-
-          public void run() {
-
-            final Document document = editor.getDocument();
-
-            CommandProcessor.getInstance().executeCommand(editor.getProject(), new Runnable() {
-              public void run() {
-                document.replaceString(0, document.getTextLength(), stringPropertyConverter.mergeComments(newDocumentContent, fileText));
-              }
-            }, "Property Sorter Plugin", null, UndoConfirmationPolicy.DO_NOT_REQUEST_CONFIRMATION);
-          }
-        });
-        messageWindowComponent.say("Properties were sorted.");
+    try {
+      VirtualFile[] files = e.getData(DataKeys.VIRTUAL_FILE_ARRAY);
+      if (files == null || files.length == 0) {
+        throw new RuntimeException("No files selected!");
       }
-      catch (ConvertException convertException) {
-        messageWindowComponent.say("There are lines containing non property styled text. File was not changed.");
-      }
-    }
-    else {
-      messageWindowComponent.say("Please select an editor window with a properties file.");
+      List<SortPropertiesResult> resultList = sortPropertiesFiles(e, files);
+      
+      ApplicationManager.getApplication().invokeAndWait(()->{
+        SortPropertiesResultsPanel dialog = new SortPropertiesResultsPanel(e.getProject(), resultList);
+        dialog.setTitle("Property Sorter Result");
+        dialog.show();
+      });
+     
+    } catch (Exception ex) {
+      Messages.showErrorDialog(e.getProject(), "Error while sorting properties. " + ex.getLocalizedMessage(),
+          "Property Sorter");
+      ex.printStackTrace();
     }
   }
 
-  private MessageWindowComponent getMessageComponent() {
-    Application application = ApplicationManager.getApplication();
-    MessageWindowComponent messageWindowComponent = application.getComponent(MessageWindowComponent.class);
-    return messageWindowComponent;
+  private List<SortPropertiesResult> sortPropertiesFiles(AnActionEvent e, VirtualFile[] files) {
+    List<SortPropertiesResult> resultList = new ArrayList<>();
+    for (VirtualFile virtualFile : files) {
+      resultList.add(sortOnePropertiesFile(e, virtualFile));
+    }
+    return resultList;
+  }
+
+  private SortPropertiesResult sortOnePropertiesFile(AnActionEvent e, VirtualFile virtualFile) {
+    SortPropertiesResult result = new SortPropertiesResult(virtualFile, false, null);
+    
+    if (virtualFile.isDirectory()) {
+      result.setMessage("this is a directory");
+      return result;
+    }
+
+    if (!virtualFile.getName().endsWith(".properties")) {
+      result.setMessage("file must have .properties extension");
+      return result;
+    }
+    
+    Document document = FileDocumentManager.getInstance().getDocument(virtualFile);
+    final String fileText = document.getText();
+    if (fileText == null) {
+      result.setMessage("No content");
+      return result;
+    }
+    
+    try {
+      Properties properties = stringPropertyConverter.convertString(fileText);
+      List<String> sortedKeys = propertySorter.getSortedKeys(properties);
+      final String newDocumentContent = stringPropertyConverter.sortAndConvertProperties(properties,
+          sortedKeys);
+      
+      ApplicationManager.getApplication().runWriteAction(
+          () -> CommandProcessor.getInstance().executeCommand(e.getProject(),
+              () -> document.replaceString(0, document.getTextLength(), 
+                  stringPropertyConverter.mergeComments(newDocumentContent, fileText)), 
+              "Property Sorter Plugin", null, UndoConfirmationPolicy.DO_NOT_REQUEST_CONFIRMATION));
+    }
+    catch (ConvertException convertException) {
+      result.setMessage("There are lines containing non property styled text. File was not changed.");
+      return result;
+    }
+    result.setSuccess(true);
+    result.setMessage("sorted properties");
+    return result;
   }
 }

--- a/src/main/java/net/wehrens/intellij/plugins/propertysorter/SortPropertiesAction.java
+++ b/src/main/java/net/wehrens/intellij/plugins/propertysorter/SortPropertiesAction.java
@@ -17,12 +17,19 @@ import com.intellij.openapi.vfs.VirtualFile;
 
 import net.wehrens.intellij.plugins.propertysorter.ui.SortPropertiesResultsPanel;
 
-
+/**
+ * Intellij plugin action used to sort multiple properties files.
+ */
 public class SortPropertiesAction extends AnAction {
 
   private PropertySorter propertySorter = new PropertySorter();
   private StringPropertyConverter stringPropertyConverter = new StringPropertyConverter();
 
+  /**
+   * Action  performed when user selects Code > Sort Properties
+   * 
+   * @param e the action event from which the list of files to sort and project information is extracted.
+   */
   public void actionPerformed(AnActionEvent e) {
     try {
       VirtualFile[] files = e.getData(DataKeys.VIRTUAL_FILE_ARRAY);

--- a/src/main/java/net/wehrens/intellij/plugins/propertysorter/SortPropertiesResult.java
+++ b/src/main/java/net/wehrens/intellij/plugins/propertysorter/SortPropertiesResult.java
@@ -2,6 +2,9 @@ package net.wehrens.intellij.plugins.propertysorter;
 
 import com.intellij.openapi.vfs.VirtualFile;
 
+/**
+ * Used to store the result of sorting one properties file.
+ */
 public class SortPropertiesResult {
   private VirtualFile virtualFile;
   private boolean success;

--- a/src/main/java/net/wehrens/intellij/plugins/propertysorter/SortPropertiesResult.java
+++ b/src/main/java/net/wehrens/intellij/plugins/propertysorter/SortPropertiesResult.java
@@ -1,0 +1,48 @@
+package net.wehrens.intellij.plugins.propertysorter;
+
+import com.intellij.openapi.vfs.VirtualFile;
+
+public class SortPropertiesResult {
+  private VirtualFile virtualFile;
+  private boolean success;
+  private String message;
+  
+  public SortPropertiesResult(VirtualFile virtualFile, boolean success, String message) {
+    this.virtualFile = virtualFile;
+    this.success = success;
+    this.message = message;
+  }
+
+  public VirtualFile getVirtualFile() {
+    return virtualFile;
+  }
+
+  public void setVirtualFile(VirtualFile virtualFile) {
+    this.virtualFile = virtualFile;
+  }
+
+  public boolean isSuccess() {
+    return success;
+  }
+
+  public void setSuccess(boolean success) {
+    this.success = success;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+
+  @Override
+  public String toString() {
+    return "PropertySortResult{" +
+        "virtualFile=" + virtualFile +
+        ", success=" + success +
+        ", message='" + message + '\'' +
+        '}';
+  }
+}

--- a/src/main/java/net/wehrens/intellij/plugins/propertysorter/ui/SortPropertiesResultsPanel.java
+++ b/src/main/java/net/wehrens/intellij/plugins/propertysorter/ui/SortPropertiesResultsPanel.java
@@ -1,0 +1,54 @@
+package net.wehrens.intellij.plugins.propertysorter.ui;
+
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import javax.swing.ListSelectionModel;
+import javax.swing.table.TableModel;
+
+import java.awt.BorderLayout;
+
+import java.awt.Dimension;
+import java.util.List;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.ui.components.JBPanel;
+import com.intellij.ui.components.JBScrollPane;
+import com.intellij.ui.table.JBTable;
+
+import net.wehrens.intellij.plugins.propertysorter.SortPropertiesResult;
+
+import org.jetbrains.annotations.Nullable;
+
+public class SortPropertiesResultsPanel extends DialogWrapper {
+
+  private JPanel panel;
+  private JBTable table;
+  
+  public SortPropertiesResultsPanel(@Nullable Project project, List<SortPropertiesResult> propertySortResults) {
+    super(project);
+    panel = new JBPanel(new BorderLayout());
+    panel.setMinimumSize(new Dimension(400, 400));
+    panel.setPreferredSize(new Dimension(600, 400));
+    TableModel tableModel = new SortPropertiesResultsTableModel(propertySortResults);
+    table = new JBTable(tableModel);
+    table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+    table.getTableHeader().setReorderingAllowed(false);
+    table.setRowSelectionAllowed(true);
+    table.setRowSelectionInterval(0, 0);
+    table.getColumnModel().getColumn(0).setPreferredWidth(200);
+    table.getColumnModel().getColumn(1).setPreferredWidth(100);
+    table.getColumnModel().getColumn(2).setPreferredWidth(450);
+    
+    panel.add(new JBScrollPane(table, JBScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED, JBScrollPane.HORIZONTAL_SCROLLBAR_NEVER),  BorderLayout.CENTER);
+
+    setModal(true);
+    init();
+  }
+
+  @Nullable
+  @Override
+  protected JComponent createCenterPanel() {
+    return panel;
+  }
+}

--- a/src/main/java/net/wehrens/intellij/plugins/propertysorter/ui/SortPropertiesResultsPanel.java
+++ b/src/main/java/net/wehrens/intellij/plugins/propertysorter/ui/SortPropertiesResultsPanel.java
@@ -20,6 +20,10 @@ import net.wehrens.intellij.plugins.propertysorter.SortPropertiesResult;
 
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Panel that contains a table which shows the results of sorting the properties files. There is one row per
+ * sorted properties file.
+ */
 public class SortPropertiesResultsPanel extends DialogWrapper {
 
   private JPanel panel;

--- a/src/main/java/net/wehrens/intellij/plugins/propertysorter/ui/SortPropertiesResultsTableModel.java
+++ b/src/main/java/net/wehrens/intellij/plugins/propertysorter/ui/SortPropertiesResultsTableModel.java
@@ -6,6 +6,10 @@ import java.util.List;
 
 import net.wehrens.intellij.plugins.propertysorter.SortPropertiesResult;
 
+/**
+ * Table model which stores the results of sorting the properties files. There is one row per
+ * sorted properties file.
+ */
 public class SortPropertiesResultsTableModel extends AbstractTableModel {
   private static final String[] COLUMN_NAMES = {"File", "Success", "Message"};
   private List<SortPropertiesResult> propertySortResults;

--- a/src/main/java/net/wehrens/intellij/plugins/propertysorter/ui/SortPropertiesResultsTableModel.java
+++ b/src/main/java/net/wehrens/intellij/plugins/propertysorter/ui/SortPropertiesResultsTableModel.java
@@ -1,0 +1,56 @@
+package net.wehrens.intellij.plugins.propertysorter.ui;
+
+import javax.swing.table.AbstractTableModel;
+
+import java.util.List;
+
+import net.wehrens.intellij.plugins.propertysorter.SortPropertiesResult;
+
+public class SortPropertiesResultsTableModel extends AbstractTableModel {
+  private static final String[] COLUMN_NAMES = {"File", "Success", "Message"};
+  private List<SortPropertiesResult> propertySortResults;
+  
+  public SortPropertiesResultsTableModel(List<SortPropertiesResult> propertySortResults) {
+    this.propertySortResults = propertySortResults;
+  }
+  
+  @Override
+  public int getRowCount() {
+    if (propertySortResults == null) {
+      return 0;
+    }
+    return propertySortResults.size();
+  }
+
+  @Override
+  public int getColumnCount() {
+    return 3;
+  }
+
+  @Override
+  public Object getValueAt(int rowIndex, int columnIndex) {
+    if (propertySortResults == null) {
+      return null;
+    }
+    if (rowIndex >= propertySortResults.size()) {
+      return null;
+    }
+
+    SortPropertiesResult propertySortResult = propertySortResults.get(rowIndex);
+    switch (columnIndex) {
+      case 0:
+        return propertySortResult.getVirtualFile().getName();
+      case 1: 
+        return propertySortResult.isSuccess();
+      case 2:
+        return propertySortResult.getMessage();
+      default:
+        return null;
+    }
+  }
+
+  @Override
+  public String getColumnName(int columnIndex) {
+    return COLUMN_NAMES[columnIndex];
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,7 +17,7 @@
 
     <version>0.1</version>
 
-    <idea-version since-build="8000"/>
+    <idea-version since-build="191"/>
 
     <application-components>
         <component>


### PR DESCRIPTION
**This is not ready to be merged in. Closed the pull request. I've done some more testing and there might potentially be a bug.**

Sort Properties action can now sort multiple files. User selects one or more properties files in Intellij and then selects Code > Sort Properties.


The result of sorting the properties files is displayed in a table in a dialog window. There is one row displayed per file.